### PR TITLE
more structurized opURI for better flexibility

### DIFF
--- a/onepassword.go
+++ b/onepassword.go
@@ -90,7 +90,7 @@ func (cli *OnePassword) ResolveOpURI(uri string) (string, error) {
 		cli.opStorage.setVaultItem(opURI.vault, opURI.item, opItem)
 		vaultItem = opItem
 	}
-	fieldValue, err := vaultItem.GetField(opURI)
+	fieldValue, err := vaultItem.GetField(cli, opURI)
 	if err != nil {
 		return "", err
 	}

--- a/onepassword.go
+++ b/onepassword.go
@@ -20,15 +20,17 @@ type OnePassword struct {
 	isInstalled bool
 }
 
+// OpURI is a struct that holds the parsed 1Password URI.
 type OpURI struct {
 	vault   string
 	item    string
 	field   string
 	section string
-	//query   string // FIXME do we need query support ?
+	//query   string // TODO query support some day
 	raw string
 }
 
+// NewOpURI creates a new OpURI instance.
 func NewOpURI(uri string) (*OpURI, error) {
 	parts := strings.Split(strings.TrimPrefix(uri, opURIPrefix), "/")
 	numParts := len(parts)

--- a/onepassword.go
+++ b/onepassword.go
@@ -20,6 +20,30 @@ type OnePassword struct {
 	isInstalled bool
 }
 
+type OpURI struct {
+	vault   string
+	item    string
+	field   string
+	section string
+	//query   string // FIXME do we need query support ?
+	raw string
+}
+
+func NewOpURI(uri string) (*OpURI, error) {
+	parts := strings.Split(strings.TrimPrefix(uri, opURIPrefix), "/")
+	numParts := len(parts)
+	var opURI OpURI
+	if numParts < 3 || numParts > 4 {
+		return nil, fmt.Errorf("invalid 1Password URI format - expected op://vault/item/field - got '%s'", uri)
+	}
+	opURI = OpURI{raw: uri, vault: parts[0], item: parts[1], field: parts[2]}
+	if numParts == 4 {
+		opURI.section = parts[2]
+		opURI.field = parts[3]
+	}
+	return &opURI, nil
+}
+
 const binName string = "op"
 const opURIPrefix string = "op://"
 const serviceAccountTokenEnv = "OP_SERVICE_ACCOUNT_TOKEN" //nolint
@@ -36,15 +60,6 @@ func New1Password(executor CommandExecutor, serviceAccountToken string) (*OnePas
 	return opCli, nil
 }
 
-// parseOpURI parses the given 1Password URI and returns its components.
-func parseOpURI(uri string) (string, string, string, error) {
-	parts := strings.Split(strings.TrimPrefix(uri, opURIPrefix), "/")
-	if len(parts) != 3 {
-		return "", "", "", fmt.Errorf("invalid 1Password URI format - expected op://vault/item/field - got '%s'", uri)
-	}
-	return parts[0], parts[1], parts[2], nil
-}
-
 // ResolveOpURI resolves the given 1Password URI and returns its value.
 // It also caches whole uri item in memory to avoid multiple calls to 1Password CLI
 // while fetching other fields from the same item.
@@ -53,7 +68,7 @@ func (cli *OnePassword) ResolveOpURI(uri string) (string, error) {
 		return uri, &InvalidOpURIError{uri: uri}
 	}
 	logrus.Info("Resolving 1password entry: ", uri)
-	vault, item, field, err := parseOpURI(uri)
+	opURI, err := NewOpURI(uri)
 	if err != nil {
 		return "", err
 	}
@@ -61,9 +76,9 @@ func (cli *OnePassword) ResolveOpURI(uri string) (string, error) {
 		logrus.Error(&OnePasswordCliNotInstalledError{})
 		return "", &OnePasswordCliNotInstalledError{}
 	}
-	vaultItem, err := cli.opStorage.getVaultItem(vault, item)
+	vaultItem, err := cli.opStorage.getVaultItem(opURI.vault, opURI.item)
 	if err != nil {
-		output, err := cli.executor.Execute("item", "get", "--format", "json", item, "--vault", vault)
+		output, err := cli.executor.Execute("item", "get", "--format", "json", opURI.item, "--vault", opURI.vault)
 		if err != nil {
 			return "", err
 		}
@@ -72,10 +87,10 @@ func (cli *OnePassword) ResolveOpURI(uri string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		cli.opStorage.setVaultItem(vault, item, opItem)
+		cli.opStorage.setVaultItem(opURI.vault, opURI.item, opItem)
 		vaultItem = opItem
 	}
-	fieldValue, err := vaultItem.GetField(field)
+	fieldValue, err := vaultItem.GetField(opURI)
 	if err != nil {
 		return "", err
 	}

--- a/onepassword.go
+++ b/onepassword.go
@@ -36,7 +36,7 @@ func NewOpURI(uri string) (*OpURI, error) {
 	if numParts < 3 || numParts > 4 {
 		return nil, fmt.Errorf("invalid 1Password URI format - expected op://vault/item/field - got '%s'", uri)
 	}
-	opURI = OpURI{raw: uri, vault: parts[0], item: parts[1], field: parts[2]}
+	opURI = OpURI{raw: uri, vault: parts[0], item: parts[1], field: parts[2], section: ""}
 	if numParts == 4 {
 		opURI.section = parts[2]
 		opURI.field = parts[3]
@@ -90,7 +90,7 @@ func (cli *OnePassword) ResolveOpURI(uri string) (string, error) {
 		cli.opStorage.setVaultItem(opURI.vault, opURI.item, opItem)
 		vaultItem = opItem
 	}
-	fieldValue, err := vaultItem.GetField(cli, opURI)
+	fieldValue, err := vaultItem.GetFieldValue(cli, opURI)
 	if err != nil {
 		return "", err
 	}

--- a/onepassword_test.go
+++ b/onepassword_test.go
@@ -54,10 +54,11 @@ func TestResolveOpURI(t *testing.T) { //nolint
 			expectedError: "invalid 1Password URI format - expected op://vault/item/field - got 'op://vault/item'",
 		},
 		{
-			name:          "should return error when uri is too long",
-			executor:      &SpyCommandExecutor{IsCliInstalled: true},
-			uri:           "op://vault/item/section/field/extra",
-			expectedError: "invalid 1Password URI format - expected op://vault/item/field - got 'op://vault/item'",
+			name:     "should return error when uri is too long",
+			executor: &SpyCommandExecutor{IsCliInstalled: true},
+			uri:      "op://vault/item/section/field/extra",
+			expectedError: "invalid 1Password URI format - expected op://vault/item/field - " +
+				"got 'op://vault/item/section/field/extra'",
 		},
 		{
 			name:     "should return error when op binary is not present",

--- a/onepassword_test.go
+++ b/onepassword_test.go
@@ -48,9 +48,15 @@ func TestResolveOpURI(t *testing.T) { //nolint
 		expectedArgs   []string
 	}{
 		{
-			name:          "should return error when uri is not valid",
+			name:          "should return error when uri is too short",
 			executor:      &SpyCommandExecutor{IsCliInstalled: true},
 			uri:           "op://vault/item",
+			expectedError: "invalid 1Password URI format - expected op://vault/item/field - got 'op://vault/item'",
+		},
+		{
+			name:          "should return error when uri is too long",
+			executor:      &SpyCommandExecutor{IsCliInstalled: true},
+			uri:           "op://vault/item/section/field/extra",
 			expectedError: "invalid 1Password URI format - expected op://vault/item/field - got 'op://vault/item'",
 		},
 		{
@@ -181,6 +187,63 @@ func Test1PasswordStorage(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, tc.executorCalls, executeCalls)
+		})
+	}
+}
+
+func TestNewOpURI(t *testing.T) {
+	testCases := []struct {
+		name          string
+		uri           string
+		expectedError string
+		expectedOpURI *OpURI
+	}{
+		{
+			name:          "should return error when uri is too short",
+			uri:           "op://vault/item",
+			expectedError: "invalid 1Password URI format - expected op://vault/item/field - got 'op://vault/item'",
+		},
+		{
+			name: "should return error when uri is too long",
+			uri:  "op://vault/item/section/field/extra",
+			expectedError: "invalid 1Password URI format - expected op://vault/item/field - " +
+				"got 'op://vault/item/section/field/extra'",
+		},
+		{
+			name: "should return valid OpURI when uri is valid with three parts",
+			uri:  "op://vault/item/field",
+			expectedOpURI: &OpURI{
+				raw:     "op://vault/item/field",
+				vault:   "vault",
+				item:    "item",
+				field:   "field",
+				section: "",
+			},
+		},
+		{
+			name: "should return valid OpURI when uri is valid with four parts",
+			uri:  "op://vault/item/section/field",
+			expectedOpURI: &OpURI{
+				raw:     "op://vault/item/section/field",
+				vault:   "vault",
+				item:    "item",
+				field:   "field",
+				section: "section",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := NewOpURI(tc.uri)
+
+			if tc.expectedError != "" {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expectedError, err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedOpURI, result)
+			}
 		})
 	}
 }

--- a/storage.go
+++ b/storage.go
@@ -64,12 +64,14 @@ func (of opFile) matchFile(uri *OpURI) bool {
 }
 
 type opSection struct {
-	Id    string `json:"id"`
+	ID    string `json:"id"`
 	Label string `json:"label"`
 }
 
 func (os opSection) matchSection(section string) bool {
-	return os.Id == section || os.Label == section
+	fmt.Printf("Comparing '%s' and '%s' with '%s'\n", os.ID, os.Label, section)
+	return os.ID == section || os.Label == section ||
+		(os.ID == "add more" && section == "") // default section is `add more` in 1password :kek:
 }
 
 // GetFieldValue returns the value of the given field, returns an error if the field does not exist.

--- a/storage.go
+++ b/storage.go
@@ -49,14 +49,14 @@ type opField struct {
 }
 
 // GetField returns the value of the given field, returns an error if the field does not exist.
-func (o opItem) GetField(field string) (string, error) {
+func (o opItem) GetField(uri *OpURI) (string, error) {
 	for _, f := range o.Fields {
-		if f.ID == field {
+		if f.ID == uri.field {
 			return f.Value, nil
 		}
-		if f.Label == field {
+		if f.Label == uri.field {
 			return f.Value, nil
 		}
 	}
-	return "", fmt.Errorf("field %s not found", field)
+	return "", fmt.Errorf("field %s not found", uri.field)
 }

--- a/storage.go
+++ b/storage.go
@@ -69,7 +69,6 @@ type opSection struct {
 }
 
 func (os opSection) matchSection(section string) bool {
-	fmt.Printf("Comparing '%s' and '%s' with '%s'\n", os.ID, os.Label, section)
 	return os.ID == section || os.Label == section ||
 		(os.ID == "add more" && section == "") // default section is `add more` in 1password :kek:
 }

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,0 +1,205 @@
+package gonepassword
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+)
+
+func TestOpStorage(t *testing.T) {
+	storage := newOPStorage()
+
+	// Test setVaultItem
+	vaultName := "testVault"
+	itemName := "testItem"
+	testItem := opItem{ID: itemName}
+	storage.setVaultItem(vaultName, itemName, testItem)
+
+	if _, ok := storage.Vaults[vaultName]; !ok {
+		t.Errorf("Vault %s was not set", vaultName)
+	}
+
+	if _, ok := storage.Vaults[vaultName].Items[itemName]; !ok {
+		t.Errorf("Item %s was not set in vault %s", itemName, vaultName)
+	}
+
+	// Test getVaultItem
+	retrievedItem, err := storage.getVaultItem(vaultName, itemName)
+	if err != nil {
+		t.Errorf("Error retrieving item: %s", err)
+	}
+
+	if !reflect.DeepEqual(retrievedItem, testItem) {
+		t.Errorf("Retrieved item does not match set item. Got %v, want %v", retrievedItem, testItem)
+	}
+}
+
+func TestOpFieldMatchField(t *testing.T) {
+	field := opField{
+		ID:      "field-id",
+		Type:    "field-type",
+		Label:   "field-label",
+		Value:   "field-value",
+		Section: opSection{ID: "section-id", Label: "section-label"},
+	}
+
+	// Test when the ID matches but the section does not
+	uri, _ := NewOpURI("op://vault/item/field-id")
+	uri.section = "wrong-section"
+	if field.matchField(uri) {
+		t.Errorf("Expected field not to match URI, but it did")
+	}
+
+	// Test when the Label matches but the section does not
+	uri.field = "field-label"
+	if field.matchField(uri) {
+		t.Errorf("Expected field not to match URI, but it did")
+	}
+
+	// Test when the section matches but neither the ID nor the Label does
+	uri.field = "wrong-field"
+	uri.section = "section-id"
+	if field.matchField(uri) {
+		t.Errorf("Expected field not to match URI, but it did")
+	}
+
+	// Test when both the ID and section match
+	uri.field = "field-id"
+	if !field.matchField(uri) {
+		t.Errorf("Expected field to match URI, but it did not")
+	}
+
+	// Test when both the Label and section match
+	uri.field = "field-label"
+	if !field.matchField(uri) {
+		t.Errorf("Expected field to match URI, but it did not")
+	}
+
+	// Test when section is empty
+	uri.section = ""
+	field.Section.ID = "add more"
+	if !field.matchField(uri) {
+		t.Errorf("Expected field to match URI, but it did not")
+	}
+}
+
+func TestOpFileMatchFile(t *testing.T) {
+	file := opFile{
+		ID:      "file-id",
+		Name:    "file-name",
+		Section: opSection{ID: "section-id", Label: "section-label"},
+	}
+
+	// Test when the ID matches but the section does not
+	uri := &OpURI{
+		raw:     "op://vault/item/file-id",
+		vault:   "vault",
+		item:    "item",
+		field:   "file-id",
+		section: "wrong-section",
+	}
+	if file.matchFile(uri) {
+		t.Errorf("Expected file not to match URI, but it did")
+	}
+
+	// Test when the Name matches but the section does not
+	uri.field = "file-name"
+	if file.matchFile(uri) {
+		t.Errorf("Expected file not to match URI, but it did")
+	}
+
+	// Test when the section matches but neither the ID nor the Name does
+	uri.field = "wrong-field"
+	uri.section = "section-id"
+	if file.matchFile(uri) {
+		t.Errorf("Expected file not to match URI, but it did")
+	}
+
+	// Test when both the ID and section match
+	uri.field = "file-id"
+	if !file.matchFile(uri) {
+		t.Errorf("Expected file to match URI, but it did not")
+	}
+
+	// Test when both the Name and section match
+	uri.field = "file-name"
+	if !file.matchFile(uri) {
+		t.Errorf("Expected file to match URI, but it did not")
+	}
+
+	// Test when section is empty
+	uri.section = ""
+	file.Section.ID = "add more"
+	if !file.matchFile(uri) {
+		t.Errorf("Expected field to match URI, but it did not")
+	}
+}
+
+func TestGetFieldValue(t *testing.T) {
+	item := opItem{
+		ID: "item-id",
+		Fields: []opField{
+			{
+				ID:      "field-id",
+				Type:    "field-type",
+				Label:   "field-label",
+				Value:   "field-value",
+				Section: opSection{ID: "section-id", Label: "section-label"},
+			},
+		},
+		Files: []opFile{
+			{
+				ID:      "file-id",
+				Name:    "file-name",
+				Section: opSection{ID: "section-id", Label: "section-label"},
+			},
+		},
+	}
+	// Test when the field exists and matches the URI
+	uri, _ := NewOpURI("op://vault/item/section-id/field-id")
+	value, err := item.GetFieldValue(nil, uri)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if value != "field-value" {
+		t.Errorf("Expected field value to be 'field-value', but got '%s'", value)
+	}
+
+	// Test when the field does not exist in the item
+	uri.field = "nonexistent-field"
+	_, err = item.GetFieldValue(nil, uri)
+	if err == nil {
+		t.Errorf("Expected error, but got nil")
+	}
+
+	// Test when the field exists but the section does not match
+	uri.field = "field-id"
+	uri.section = "wrong-section"
+	_, err = item.GetFieldValue(nil, uri)
+	if err == nil {
+		t.Errorf("Expected error, but got nil")
+	}
+
+	// Test when the field is a file
+	uri, _ = NewOpURI("op://vault/item/section-id/file-id")
+	executor := &SpyCommandExecutor{IsCliInstalled: true, ExecuteOutput: []byte("itsa me - a file!")}
+	cli, err := New1Password(executor, "")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	fieldValue, _ := item.GetFieldValue(cli, uri)
+	assert.Equal(t, []string{"read", "op://vault/item/section-id/file-id"}, executor.ExecuteArgs)
+	assert.Equal(t, "itsa me - a file!", fieldValue)
+
+	// Test when the fetching file fails
+	uri, _ = NewOpURI("op://vault/item/section-id/file-id")
+	executor = &SpyCommandExecutor{IsCliInstalled: true, ExecuteError: errors.New("oh noez")}
+	cli, err = New1Password(executor, "")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	_, err = item.GetFieldValue(cli, uri)
+	assert.Equal(t, []string{"read", "op://vault/item/section-id/file-id"}, executor.ExecuteArgs)
+	assert.Equal(t, "oh noez", err.Error())
+}


### PR DESCRIPTION
- Adds support for sections, regular op url consists of `op://vault/item/field` but if you use sections it can become `op://vault/item/section/field`
- Adds support for files - files are returned as seperate object while fetching item from 1password and require additional treatment. Now if library detects a file it will fetch it using additional cli call `op read op_url`

Changes should be backwards compatible

```
go get -u github.com/jzyinq/gonepassword@feature-custom-fields-support
```